### PR TITLE
Update json-canonicalization version to 0.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ gem 'webpacker', '~> 5.4'
 gem 'webpush', github: 'ClearlyClaire/webpush', ref: 'f14a4d52e201128b1b00245d11b6de80d6cfdcd9'
 gem 'webauthn', '~> 3.0'
 
+gem 'json-canonicalization', '~> 0.3.3'
 gem 'json-ld'
 gem 'json-ld-preloaded', '~> 3.2'
 gem 'rdf-normalize', '~> 0.5'


### PR DESCRIPTION
안녕하세요, 현재 휘핑 에디션에서 빌드를 위해 `gem install bundler --no-document` 커맨드 실행 시 에러가 발생하여 수정 PR 올립니다.
해당 문제의 원인은 `json-canonicalization` 버전 `0.3.2`가 yanked 되었기 때문입니다([#](https://rubygems.org/gems/json-canonicalization/versions)).
따라서 바로 위 버전인 0.3.3으로 수정했습니다.